### PR TITLE
Prefer usage of ReadOnlyMemory<char> to string to avoid allocation

### DIFF
--- a/src/FParser6/Core.fs
+++ b/src/FParser6/Core.fs
@@ -216,12 +216,12 @@ module FParser =
       else
         expectedAt c label pos
 
-  let inline pstringSat1 label ([<InlineIfLambda>] sat) : string FParser = 
+  let inline pstringSat1 label ([<InlineIfLambda>] sat) : ReadOnlyMemory<char> FParser = 
     fun c ->
       let i = c.Pos
       let e = scan c sat i
       if i < e then
-        successAt c (c.Input.Substring(i, e - i)) e
+        successAt c (c.Input.AsMemory(i, e - i)) e
       else
         expectedAt c label i
 


### PR DESCRIPTION
Avoid creation of string for Variable

Hence, less memory usage...


|                     Method | Job |                                                EnvironmentVariables |       Mean |    Error |    StdDev |     Median |  Gen 0 | Allocated |
|--------------------------- |---- |-------------------------------------------------------------------- |-----------:|---------:|----------:|-----------:|-------:|----------:|
|   Baseline_BasicExpression | PGO | DOTNET_TieredPGO=1,DOTNET_TC_QuickJitForLoops=1,DOTNET_ReadyToRun=0 |   232.6 ns |  4.76 ns |  12.21 ns |   238.8 ns | 0.0420 |     176 B |
|    FParser_BasicExpression | PGO | DOTNET_TieredPGO=1,DOTNET_TC_QuickJitForLoops=1,DOTNET_ReadyToRun=0 |   331.7 ns |  6.65 ns |  16.94 ns |   336.9 ns | 0.0496 |     208 B |
|    FParsec_BasicExpression | PGO | DOTNET_TieredPGO=1,DOTNET_TC_QuickJitForLoops=1,DOTNET_ReadyToRun=0 |   960.0 ns | 22.84 ns |  67.35 ns |   987.0 ns | 0.1240 |     520 B |
| Baseline_ComplexExpression | PGO | DOTNET_TieredPGO=1,DOTNET_TC_QuickJitForLoops=1,DOTNET_ReadyToRun=0 |   823.6 ns | 16.53 ns |  40.87 ns |   835.3 ns | 0.1602 |     672 B |
|  FParser_ComplexExpression | PGO | DOTNET_TieredPGO=1,DOTNET_TC_QuickJitForLoops=1,DOTNET_ReadyToRun=0 | 1,017.3 ns | 22.06 ns |  62.95 ns | 1,036.9 ns | 0.1678 |     704 B |
|  FParsec_ComplexExpression | PGO | DOTNET_TieredPGO=1,DOTNET_TC_QuickJitForLoops=1,DOTNET_ReadyToRun=0 | 2,621.5 ns | 72.43 ns | 213.57 ns | 2,738.6 ns | 0.3166 |   1,328 B |
|   Baseline_BasicExpression | STD |                                                               Empty |   307.5 ns |  7.52 ns |  22.17 ns |   316.8 ns | 0.0420 |     176 B |
|    FParser_BasicExpression | STD |                                                               Empty |   386.7 ns |  8.48 ns |  25.01 ns |   398.0 ns | 0.0496 |     208 B |
|    FParsec_BasicExpression | STD |                                                               Empty | 1,246.2 ns | 24.87 ns |  66.82 ns | 1,269.5 ns | 0.1240 |     520 B |
| Baseline_ComplexExpression | STD |                                                               Empty |   945.4 ns | 18.93 ns |  34.13 ns |   957.2 ns | 0.1602 |     672 B |
|  FParser_ComplexExpression | STD |                                                               Empty | 1,210.2 ns | 32.14 ns |  94.76 ns | 1,248.6 ns | 0.1678 |     704 B |
|  FParsec_ComplexExpression | STD |                                                               Empty | 3,316.8 ns | 66.30 ns | 138.39 ns | 3,349.8 ns | 0.3166 |   1,328 B |